### PR TITLE
69 - Preserve Profile Page Navigation State

### DIFF
--- a/actions/app.go
+++ b/actions/app.go
@@ -62,6 +62,7 @@ func App() *buffalo.App {
 		// TODO: should we even have list pages (since there is search)
 		app.GET("/lists/{type}", ListPageHandler)
 		app.GET("/entities/{type}/{id}", EntityPageHandler)
+		app.GET("/entities/{type}/{id}/{tabName}", EntityPageHandler)
 		app.GET("/docs", DocPageHandler)
 		app.GET("/docs/elements/{element}", ElementDocPageHandler)
 

--- a/assets/js/elements.js
+++ b/assets/js/elements.js
@@ -1,4 +1,5 @@
 import './elements/vaadin-theme.js'
+import './elements/person-navigation.js'
 import './elements/publication-list.js'
 import './elements/publication.js'
 import './elements/publication-author.js'

--- a/assets/js/elements/person-navigation.js
+++ b/assets/js/elements/person-navigation.js
@@ -1,0 +1,91 @@
+import { LitElement } from 'lit-element';
+
+class PersonNavigation extends LitElement {
+
+  constructor() {
+    super();
+    this.browsingState = {};
+    this.navFrom = this.navFrom.bind(this);
+    this.navTo = this.navTo.bind(this);
+    this.trapLinks = this.trapLinks.bind(this);
+    this.handleTabSelected = this.handleTabSelected.bind(this);
+  }
+
+  firstUpdated() {
+    document.addEventListener('DOMContentLoaded',this.navFrom);
+    document.addEventListener('click',this.trapLinks );
+    document.addEventListener('tabSelected',this.handleTabSelected);
+  }
+
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener('DOMContentLoaded',this.navFrom);
+    document.removeEventListener('click',this.trapLinks);
+  }
+
+  trapLinks(e) {
+    const eventPath = e.composedPath();
+    const linkTarget = eventPath.find(n => n.href);
+    if (linkTarget) {
+      e.preventDefault();
+      this.browsingState.navTo = linkTarget.href;
+      const publication = eventPath.find(n => n.tagName === 'VIVO-PUBLICATION');
+      if (publication) {
+        const publicationList = this.getPublicationList();
+        this.browsingState.currentSection = "publications";
+        this.browsingState.sectionSort = publicationList.getSort();
+        this.browsingState.returnTo = publication.publicationUrl;
+      }
+      this.navTo();
+    }
+  }
+
+  navFrom() {
+    const url = new URL(window.location.href);
+    const incomingBrowsingState = {};
+    for(let key of url.searchParams.keys()) {
+      incomingBrowsingState[key] = url.searchParams.get(key);
+    }
+    const { currentTab, currentSection, sectionSort, returnTo, navTo } = incomingBrowsingState;
+    if (currentTab) {
+      const tabs = this.getMainTabs();
+      if (tabs) {
+        tabs.selectTabById(currentTab);
+      }
+    }
+    switch(currentSection) {
+      case 'publications':
+        if (sectionSort) {
+          const publicationList = this.getPublicationList();
+          if (publicationList) {
+            publicationList.setSort(sectionSort);
+            publicationList.showPublication(returnTo);
+          }
+        }
+    }
+
+  }
+
+  navTo() {
+    const searchParams = new URLSearchParams(this.browsingState);
+    window.history.replaceState({},'', `${window.location.pathname}?${searchParams.toString()}`);
+    window.location.href = this.browsingState.navTo;
+  }
+
+  handleTabSelected(e) {
+    const tab = e.detail;
+    this.browsingState.currentTab = tab.id
+  }
+
+  getMainTabs() {
+    return document.querySelector('vivo-tabs');
+  }
+
+  getPublicationList() {
+    return document.querySelector('vivo-publication-list');
+  }
+
+}
+
+customElements.define('vivo-person-navigation',PersonNavigation);

--- a/assets/js/elements/person-navigation.js
+++ b/assets/js/elements/person-navigation.js
@@ -22,6 +22,7 @@ class PersonNavigation extends LitElement {
     super.disconnectedCallback();
     document.removeEventListener('DOMContentLoaded',this.navFrom);
     document.removeEventListener('click',this.trapLinks);
+    document.removeEventListener('tabSelected',this.handleTabSelected);
   }
 
   trapLinks(e) {

--- a/assets/js/elements/publication-author-list.js
+++ b/assets/js/elements/publication-author-list.js
@@ -45,6 +45,9 @@ class PublicationAuthorList extends LitElement {
       ::slotted(vivo-publication-author):after {
         content: ", ";
       }
+      ::slotted(vivo-publication-author:last-child):after {
+        content: "";
+      }
       .truncated-authors {
         white-space: nowrap;
       }

--- a/assets/js/elements/publication-author.js
+++ b/assets/js/elements/publication-author.js
@@ -1,10 +1,20 @@
 import { LitElement, html, css } from "lit-element";
 
 class PublicationAuthor extends LitElement {
+
   static get properties() {
     return {
       profileUrl: { attribute: "profile-url", type: String }
     };
+  }
+
+  handleAuthorClick(e) {
+    this.dispatchEvent(new CustomEvent('authorClicked', {
+      detail: this,
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }));
   }
 
   static get styles() {
@@ -12,7 +22,7 @@ class PublicationAuthor extends LitElement {
       :host {
         display: inline;
       }
-      a.author {
+      ::slotted(*) {
         color: var(--darkNeutralColor);
         text-decoration: none;
         white-space: nowrap;
@@ -24,17 +34,9 @@ class PublicationAuthor extends LitElement {
   }
 
   render() {
-    if (this.profileUrl) {
-      return html`
-        <a class="author" href="${this.profileUrl}">
-          <slot></slot>
-        </a>
-      `;
-    } else {
-      return html`
-        <slot></slot>
-      `;
-    }
+    return html`
+      <slot @click="${this.handleAuthorClick}"></slot>
+    `
   }
 }
 

--- a/assets/js/elements/publication.js
+++ b/assets/js/elements/publication.js
@@ -1,8 +1,10 @@
 import { LitElement, html, css } from "lit-element";
 
 class Publication extends LitElement {
+
   static get properties() {
     return {
+      id: { type: String },
       publicationUrl: {
         attribute: "publication-url",
         type: String,
@@ -23,7 +25,8 @@ class Publication extends LitElement {
           }
         },
         reflect: true
-      }
+      },
+      onSelect: { type: Object }
     };
   }
 
@@ -33,18 +36,11 @@ class Publication extends LitElement {
         display: block;
         padding-top: 1em;
       }
-      :host([link-decorate="true"]) .title a {
-        text-decoration: underline;
-      }
-      .title {
+      ::slotted([slot="title"]) {
         margin-bottom: 0.5em;
         font-weight: bold;
         color: var(--linkColor);
-      }
-      .title a {
         text-decoration: none;
-        background-color: transparent;
-        color: var(--linkColor);
       }
       ::slotted([slot="authors"]), ::slotted([slot="publisher"]) {
         margin-right: 0.5em;
@@ -79,18 +75,19 @@ class Publication extends LitElement {
     `;
   }
 
+  handlePublicationClick(e) {
+    this.dispatchEvent(new CustomEvent('publicationClicked', {
+      detail: this,
+      bubbles: true,
+      cancelable: false,
+      composed: true
+    }));
+  }
+
   render() {
     return html`
       <div class="title">
-        ${this.publicationUrl
-          ? html`
-              <a href="${this.publicationUrl}">
-                <slot name="title"></slot>
-              </a>
-            `
-          : html`
-              <slot name="title"></slot>
-            `}
+        <slot name="title" @click="${this.handlePublicationClick}"></slot>
       </div>
       <slot name="authors"></slot>
       <slot name="publisher"></slot>

--- a/assets/js/elements/tabs.js
+++ b/assets/js/elements/tabs.js
@@ -47,6 +47,10 @@ class Tabs extends LitElement {
     }
   }
 
+  selectTabById(tabId) {
+    this.selectTab(this.querySelector(`vivo-tab#${tabId}`));
+  }
+
   selectTab(tab) {
     if (tab) {
       let tabs = this.querySelectorAll('vivo-tab');
@@ -56,6 +60,12 @@ class Tabs extends LitElement {
       let panels = this.querySelectorAll('vivo-tab-panel');
       panels.forEach((t) => t.removeAttribute('selected'));
       panels[index].setAttribute('selected', 'selected');
+      this.dispatchEvent(new CustomEvent('tabSelected', {
+        detail: tab,
+        bubbles: true,
+        cancelable: false,
+        composed: true
+      }));
     }
   }
 
@@ -79,7 +89,7 @@ class Tabs extends LitElement {
       :host {
         display: flex;
         flex-wrap: wrap;
-      }   
+      }
     `
   }
 

--- a/templates/entity_pages/person/person.html
+++ b/templates/entity_pages/person/person.html
@@ -1,8 +1,7 @@
-<%= javascriptTag("person.js") %>
+<vivo-person-navigation></vivo-person-navigation>
 <%
   let person = data["person"]
 %>
-
 <div class="container">
 
    <aside>
@@ -131,7 +130,9 @@
             <vivo-publication-list>
                <%= for (idx, p) in person["publications"] { %>
                <vivo-publication publication-url="/entities/publication/<%= p["id"] %>" published-date="<%= p["publicationDate"] %>">
-                  <div slot="title"><%= p["title"] %></div>
+                  <a slot="title" href="/entities/publication/<%= p["id"] %>">
+                    <%= p["title"] %>
+                  </a>
                   <vivo-publication-author-list slot="authors">
                      <%= for (a) in p["authors"] { %>
                      <vivo-publication-author profile-url="/entities/person/<%= a["id"] %>">
@@ -172,3 +173,4 @@
    </main>
 
 </div><!-- end container -->
+<%= javascriptTag("person.js") %>

--- a/yarn.lock
+++ b/yarn.lock
@@ -980,14 +980,6 @@
   resolved "https://registry.yarnpkg.com/@types/zen-observable/-/zen-observable-0.8.0.tgz#8b63ab7f1aa5321248aad5ac890a485656dcea4d"
   integrity sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg==
 
-"@vaadin/router@^1.5.2":
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/@vaadin/router/-/router-1.5.2.tgz#a80a1146e03806d4476c957c69681e6b681fcc66"
-  integrity sha512-Byjz/FQ7ohGZRrxZnoZ2DJgTUWtj7YLKFY9L4iaWw/NW9fklPyn+wYRgPfLc/uk3srBr1Hc9JWg/b++lE6lyfw==
-  dependencies:
-    "@vaadin/vaadin-usage-statistics" "^2.0.8"
-    path-to-regexp "2.4.0"
-
 "@vaadin/vaadin-control-state-mixin@^2.1.1":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@vaadin/vaadin-control-state-mixin/-/vaadin-control-state-mixin-2.1.3.tgz#509998350611651acfa8db1506fc12d925861b48"
@@ -1104,7 +1096,7 @@
     "@polymer/polymer" "^3.0.0"
     lit-element "^2.0.0"
 
-"@vaadin/vaadin-usage-statistics@^2.0.8", "@vaadin/vaadin-usage-statistics@^2.1.0":
+"@vaadin/vaadin-usage-statistics@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@vaadin/vaadin-usage-statistics/-/vaadin-usage-statistics-2.1.0.tgz#9c0fd71dded80f401bcdfbcb3f45b5640fc4256d"
   integrity sha512-e81nbqY5zsaYhLJuOVkJkB/Um1pGK5POIqIlTNhUfjeoyGaJ63tiX8+D5n6F+GgVxUTLUarsKa6SKRcQel0AzA==
@@ -5366,11 +5358,6 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
-
-path-to-regexp@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
-  integrity sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==
 
 path-type@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Add PersonNavigation component to add 'sticky' nav to person page.

Listen for interaction events and encode browsing state in the
querystring so returning via the back button will take you to where
you were before you left.

Fix author list styling - remove trailing comma

Pub List Fix;
Change to using a hidden slot and collecting nodes with the 'slotchange'
This fixes chrome display bug and removes need for rendering with
'unsafeHTML'