### PR TITLE
#190: add min-height to facet popup to keep size during search

### DIFF
--- a/assets/js/search/facet-popup.js
+++ b/assets/js/search/facet-popup.js
@@ -222,6 +222,7 @@ class FacetPopupMessage extends Faceter(LitElement) {
       flex-direction: column;
       flex-wrap: wrap;
       max-height: 200px;
+      min-height: 200px;
       min-width: 100px;
       max-width: 32rem;
       overflow: auto;


### PR DESCRIPTION
This seems to keep the facet pop-up the same size - even with limited list in search.  