### PR TITLE
Add reverse proxy to buffalo app

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 GRAPHQL_ENDPOINT=http://localhost:9000/graphql
+GRAPHQL_ENDPOINT_BASE=http://localhost:9000/
 GO_ENV=development
 SITE_URL=http://localhost:4200
 PORT=4200

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gobuffalo/packr/v2 v2.4.0
 	github.com/gobuffalo/plush v3.8.2+incompatible
 	github.com/gobuffalo/suite v2.7.0+incompatible
+	github.com/gorilla/mux v1.7.2
 	github.com/jackc/pgx v3.3.0+incompatible // indirect
 	github.com/machinebox/graphql v0.2.2
 	github.com/markbates/going v1.0.3 // indirect


### PR DESCRIPTION
Proxy through to the graphql endpoint running in scholars discovery. This
should allow for a more simple deployment. Needs testing.